### PR TITLE
Work around VirtualBox shared folders sync issue

### DIFF
--- a/data/conf/nginx/demovibes.conf
+++ b/data/conf/nginx/demovibes.conf
@@ -1,6 +1,11 @@
 server {
   listen 8080;
 
+  # sendfile() usage results in corrupted files when editing files that are
+  # in VirtualBox shared folders. Turn it off. See:
+  # https://www.vagrantup.com/docs/synced-folders/virtualbox.html
+  sendfile off;
+
     client_max_body_size 100M;
 
     access_log /var/log/nginx/nectarine.access.log combined;


### PR DESCRIPTION
There's a synchronisation bug with VirtualBox shared folders when
editing files on a host system that are served by Nginx using
sendfile(). Fix by setting sendfile usage to off in the Nginx
configuration file.

See https://www.vagrantup.com/docs/synced-folders/virtualbox.html and
further for more information.